### PR TITLE
Remove h2 elements from table of contents

### DIFF
--- a/Pages/PostList.cshtml
+++ b/Pages/PostList.cshtml
@@ -11,7 +11,7 @@
                 <img src=@($"https://picsum.photos/seed/{post.URLSlug}/160/100") width="160" height="100" loading="lazy">
             </a>
         </div>
-        <div class="title"><h2><a asp-page="Post" asp-route-title="@post.URLSlug">@post.Title</a></h2></div>
+        <div class="title"><a asp-page="Post" asp-route-title="@post.URLSlug">@post.Title</a></div>
         <div class="metadata">
             <div class="author">@post.Author</div>
             <div class="divider">-</div>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -133,7 +133,7 @@ body {
   grid-area: title;
 }
 
-.post-list-element .title h2 {
+.post-list-element .title a {
   font-size: 1.6rem;
   font-weight: 500;
 }


### PR DESCRIPTION
- An `h2` [should](https://html.spec.whatwg.org/multipage/sections.html#headings-and-sections) represent a heading for its section (`article`, `section`, implicit section, etc.).
- The current setup of this page implies that each entry in the table of contents constitutes its own implicit section. That implication is incorrect. Rather, a table of contents is more akin to an ordered (or unordered) list than to a series of sections that actually contain substantive content.
- Therefore, each entry in the table of contents *should not* be an `h2`.